### PR TITLE
Fix: persist pinned note across game restarts

### DIFF
--- a/src/main/java/com/chaosthedude/notes/Notes.java
+++ b/src/main/java/com/chaosthedude/notes/Notes.java
@@ -1,5 +1,12 @@
 package com.chaosthedude.notes;
 
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.lwjgl.glfw.GLFW;
@@ -7,34 +14,69 @@ import org.lwjgl.glfw.GLFW;
 import com.chaosthedude.notes.config.NotesConfig;
 import com.chaosthedude.notes.gui.SelectNoteScreen;
 import com.chaosthedude.notes.note.Note;
+import com.chaosthedude.notes.util.FileUtils;
 
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
 import net.minecraft.client.KeyMapping;
 import net.minecraft.resources.Identifier;
 
 public class Notes implements ClientModInitializer {
 
 	public static final String MODID = "notes";
-
 	public static final Logger LOGGER = LogManager.getLogger(MODID);
-
 	public static Note pinnedNote;
-
 	private static KeyMapping openNotes;
 
 	@Override
 	public void onInitializeClient() {
 		NotesConfig.load();
-		
+
 		openNotes = KeyBindingHelper.registerKeyBinding(new KeyMapping("key.openNotes", GLFW.GLFW_KEY_N, new KeyMapping.Category(Identifier.fromNamespaceAndPath(MODID, "keys"))));
-		
+
 		ClientTickEvents.END_CLIENT_TICK.register(client -> {
-		    while (openNotes.isDown()) {
-		    	client.setScreen(new SelectNoteScreen(client.screen));
-		    }
+			while (openNotes.isDown()) {
+				client.setScreen(new SelectNoteScreen(client.screen));
+			}
 		});
+
+		ClientPlayConnectionEvents.JOIN.register((handler, sender, client) -> {
+			loadPinnedNote();
+		});
+	}
+
+	public static void savePinnedNote() {
+		File stateFile = new File(FileUtils.getRootSaveDirectory(), "pinned.txt");
+		try {
+			if (pinnedNote == null) {
+				stateFile.delete();
+			} else {
+				try (BufferedWriter writer = new BufferedWriter(new FileWriter(stateFile))) {
+					writer.write(pinnedNote.getSaveFile().getCanonicalPath());
+				}
+			}
+		} catch (IOException e) {
+			LOGGER.error("Failed to save pinned note state", e);
+		}
+	}
+
+	public static void loadPinnedNote() {
+		pinnedNote = null;
+		File stateFile = new File(FileUtils.getRootSaveDirectory(), "pinned.txt");
+		if (!stateFile.exists()) return;
+		try (BufferedReader reader = new BufferedReader(new FileReader(stateFile))) {
+			String path = reader.readLine();
+			if (path != null && !path.trim().isEmpty()) {
+				File noteFile = new File(path.trim());
+				if (noteFile.exists()) {
+					pinnedNote = new Note(noteFile);
+				}
+			}
+		} catch (IOException e) {
+			LOGGER.error("Failed to load pinned note state", e);
+		}
 	}
 
 }

--- a/src/main/java/com/chaosthedude/notes/gui/EditNoteScreen.java
+++ b/src/main/java/com/chaosthedude/notes/gui/EditNoteScreen.java
@@ -106,6 +106,7 @@ public class EditNoteScreen extends Screen {
 			minecraft.setScreen(new ViewNoteScreen(parentScreen, note));
 			if (pinned) {
 				Notes.pinnedNote = note;
+				Notes.savePinnedNote();
 			}
 		}));
 		globalButton = addRenderableWidget(new NotesButton(10, 65, 110, 20, Component.translatable("notes.global").append(Component.literal(": ").append(note.getScope() == Scope.GLOBAL ? Component.translatable("notes.on") : Component.translatable("notes.off"))), (onPress) -> {

--- a/src/main/java/com/chaosthedude/notes/gui/NotesListEntry.java
+++ b/src/main/java/com/chaosthedude/notes/gui/NotesListEntry.java
@@ -67,8 +67,10 @@ public class NotesListEntry extends ObjectSelectionList.Entry<NotesListEntry> {
 	public void togglePin() {
 		if (isPinned()) {
 			Notes.pinnedNote = null;
+			Notes.savePinnedNote();
 		} else {
 			Notes.pinnedNote = note;
+			Notes.savePinnedNote();
 			mc.setScreen(null);
 		}
 	}

--- a/src/main/java/com/chaosthedude/notes/gui/ViewNoteScreen.java
+++ b/src/main/java/com/chaosthedude/notes/gui/ViewNoteScreen.java
@@ -123,9 +123,11 @@ public class ViewNoteScreen extends Screen {
 	private void togglePin() {
 		if (isPinned()) {
 			Notes.pinnedNote = null;
+			Notes.savePinnedNote();
 			pinButton.setMessage(Component.translatable("notes.pin"));
 		} else {
 			Notes.pinnedNote = note;
+			Notes.savePinnedNote();
 			pinButton.setMessage(Component.translatable("notes.unpin"));
 		}
 	}

--- a/src/main/java/com/chaosthedude/notes/note/Note.java
+++ b/src/main/java/com/chaosthedude/notes/note/Note.java
@@ -207,6 +207,7 @@ public class Note {
 	public void delete() {
 		if (isPinned()) {
 			Notes.pinnedNote = null;
+			Notes.savePinnedNote();
 		}
 
 		saveFile.delete();


### PR DESCRIPTION
Pinned note state was only kept in memory, causing it to reset on every game launch. This saves the pinned note's path to pinned.txt in the notes directory on pin/unpin, and restores it on world join.

Fixes #5

I did not increment the mod version. Only made changes for Fabric 1.21.11 since I only play this version.